### PR TITLE
Fix: Correct EMR tagging and improve context querying

### DIFF
--- a/astra/core.py
+++ b/astra/core.py
@@ -206,7 +206,7 @@ class AstraCore:
                     if self.memory_core.is_memorable_by_ai(aux_client, reply, aux_model_name):
                         analysis = self.analyzer.analyze(reply)
                         if self.filter.should_save(analysis):
-                            emr_tag = self.memory_core.tag_fragment(reply)
+                            emr_tag = self.memory_core.tag_fragment(reply, analysis.get("emotions", []))
                             tag_string = self.memory_core.format_tags(emr_tag, analysis)
                             self.memory_core.save_fragment(reply, tag_string, user_input, client)
 

--- a/astra/memory/core.py
+++ b/astra/memory/core.py
@@ -169,8 +169,9 @@ class Core:
                        (text, tag, date, user_input))
         self.conn.commit()
 
-    def tag_fragment(self, text: str) -> str:
-        # Por defecto, reemplaza por tu lógica avanzada o llama a tu analyzer externo
+    def tag_fragment(self, text: str, emotions: list[str]) -> str:
+        if emotions:
+            return emotions[0]
         return "reflexión"
 
     def format_tags(self, emr_tag: str, analysis: dict) -> str:

--- a/astra/tests/test_memory_core.py
+++ b/astra/tests/test_memory_core.py
@@ -1,0 +1,57 @@
+import unittest
+import os
+# Adjust the import path if necessary based on how tests are run (e.g., from project root)
+# This assumes tests might be run from the root directory of the project.
+from astra.memory.core import Core 
+
+# Define a temporary database file for testing
+TEST_DB_FILE = "test_astra_memory.db"
+
+class TestCoreTagFragment(unittest.TestCase):
+
+    def setUp(self):
+        # Initialize Core with a temporary database for each test
+        # This ensures that if Core's __init__ has side effects (like creating a DB),
+        # they are isolated to the test.
+        self.core_instance = Core(db_file=TEST_DB_FILE)
+        # Ensure a clean state by removing the test DB if it exists from a previous run
+        if os.path.exists(TEST_DB_FILE):
+            os.remove(TEST_DB_FILE)
+        # Re-initialize to create the DB for the current test
+        self.core_instance = Core(db_file=TEST_DB_FILE)
+
+
+    def tearDown(self):
+        # Clean up the temporary database file after each test
+        if os.path.exists(TEST_DB_FILE):
+            os.remove(TEST_DB_FILE)
+
+    def test_tag_fragment_with_emotions(self):
+        """Test that tag_fragment returns the first emotion when emotions are present."""
+        self.assertEqual(self.core_instance.tag_fragment("some text", ["ansiedad", "culpa"]), "ansiedad")
+        self.assertEqual(self.core_instance.tag_fragment("other text", ["duelo"]), "duelo")
+        self.assertEqual(self.core_instance.tag_fragment("text with one emotion", ["alegria"]), "alegria")
+
+    def test_tag_fragment_without_emotions(self):
+        """Test that tag_fragment returns 'reflexión' when no emotions are present."""
+        self.assertEqual(self.core_instance.tag_fragment("some text", []), "reflexión")
+
+    def test_tag_fragment_with_empty_string_as_first_emotion(self):
+        """Test that tag_fragment returns an empty string if it's the first emotion."""
+        # This behavior depends on the requirements: should an empty string tag be allowed?
+        # Assuming current logic: if it's in the list, it's returned.
+        self.assertEqual(self.core_instance.tag_fragment("some text", ["", "culpa"]), "")
+
+    def test_tag_fragment_with_none_in_emotions_list(self):
+        """Test behavior if None is in the emotions list (should ideally be filtered before)."""
+        # This assumes that the list contains strings as per type hint List[str]
+        # If None could be passed, this test might fail or function might need adjustment
+        # For now, assuming valid string inputs or type error from caller.
+        # Let's test with a valid list first, then consider edge cases if they arise.
+        # This test case might be redundant if type hinting is strictly followed by callers.
+        # self.assertEqual(self.core_instance.tag_fragment("text with None", [None, "alegria"]), None) # Example if None was possible
+        pass # Placeholder if we stick to List[str]
+
+if __name__ == '__main__':
+    # This allows running the tests directly from the command line
+    unittest.main()


### PR DESCRIPTION
This commit addresses an issue where EMR (Emotional Medical Record) data was not being correctly tagged when saved to the database, which in turn affected its ability to be queried effectively for improving AI context.

Changes include:

1.  **Modified `astra.memory.core.Core.tag_fragment()`:**
    *   The method now accepts a list of detected emotions.
    *   It uses the first detected emotion as the primary EMR tag for a memory fragment.
    *   Defaults to "reflexión" if no emotions are detected.
    *   This replaces the previous placeholder behavior that always returned "reflexión".

2.  **Updated `astra.core.AstraCore.run_chat()`:**
    *   The call to `tag_fragment` now passes the list of detected emotions
        from `CompositeAnalyzer`'s output.

3.  **Impact on EMR Saving & Querying:**
    *   EMR fragments are now saved with specific emotion tags (e.g., "duelo",
        "ansiedad") in the database.
    *   The `ContextBuilder`'s `load_last_fragments` method can now
        more accurately score and prioritize EMR-tagged fragments for inclusion
        in the AI's initial context, provided `emr_weights.json` is
        configured with appropriate weights for these emotion tags.
    *   Textually relevant fragments retrieved during conversation flow
        (`filter_relevant_fragments`) will now display their correct EMR
        nature to the LLM via `encode_fragments_with_emr`.

4.  **Added Unit Tests:**
    *   Created `astra/tests/test_memory_core.py` with unit tests for
        the `tag_fragment` method to ensure its correct behavior with
        various emotion inputs.

These changes ensure that EMR data is properly captured and utilized, enhancing the AI's contextual understanding and memory capabilities.